### PR TITLE
Enhance index with dark mode and typing hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,27 @@
         .progress {
             margin-bottom: 1rem; /* Add some space below progress bars */
         }
+        #typed-text {
+            display: inline-block;
+            border-right: 2px solid #fff;
+            padding-right: 5px;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        body.dark-mode {
+            background-color: #121212;
+            color: #eaeaea;
+        }
+        body.dark-mode .w3-bar,
+        body.dark-mode .w3-modal-content,
+        body.dark-mode .w3-card-4,
+        body.dark-mode .w3-container.w3-white {
+            background-color: #1f1f1f;
+            color: #eaeaea;
+        }
+        body.dark-mode a {
+            color: #80d0ff;
+        }
     </style>
 </head>
 <body>
@@ -52,6 +73,7 @@
       <a href="#portfolio" class="w3-bar-item w3-button w3-hide-small"><i class="fa fa-th"></i> PORTFOLIO</a>
       <a href="https://accounts.google.com/ServiceLogin?service=wise&passive=true&continue=http%3A%2F%2Fdrive.google.com%2F%3Futm_source%3Den&utm_medium=button&utm_campaign=web&utm_content=gotodrive&usp=gtd&ltmpl=drive" target="_blank" class="w3-bar-item w3-button w3-hide-small"><i class="fab fa-google-drive"></i> GOOGLE DRIVE</a>
       <a href="https://www.facebook.com/messages/t/4067569863335888" target="_blank" class="w3-bar-item w3-button w3-hide-small"><i class="fa fa-envelope"></i> CONTACT</a>
+      <button id="darkModeToggle" class="w3-bar-item w3-button w3-right" aria-label="Toggle dark mode"><i class="fa fa-moon"></i></button>
       <!-- Search functionality removed -->
     </div>
   
@@ -61,13 +83,14 @@
       <a href="#portfolio" class="w3-bar-item w3-button" onclick="toggleFunction()">PORTFOLIO</a>
       <a href="https://accounts.google.com/ServiceLogin?service=wise&passive=true&continue=http%3A%2F%2Fdrive.google.com%2F%3Futm_source%3Den&utm_medium=button&utm_campaign=web&utm_content=gotodrive&usp=gtd&ltmpl=drive" target="_blank" class="w3-bar-item w3-button" onclick="toggleFunction()"><i class="fab fa-google-drive"></i> GOOGLE DRIVE</a>
       <a href="https://www.facebook.com/messages/t/4067569863335888" target="_blank" class="w3-bar-item w3-button" onclick="toggleFunction()">CONTACT</a>
+      <button class="w3-bar-item w3-button" onclick="toggleFunction(); document.getElementById('darkModeToggle').click();"><i class="fa fa-moon"></i> Dark Mode</button>
       <!-- Search link removed -->
     </div>
 </nav>
 
 <header class="bgimg-1 w3-display-container w3-opacity-min" id="home">
   <div class="w3-display-middle" style="white-space:nowrap;">
-    <span class="w3-center w3-padding-large w3-black w3-xlarge w3-wide w3-animate-opacity">Server <span class="w3-hide-small">Among</span> Us</span>
+    <span id="typed-text" class="w3-center w3-padding-large w3-black w3-xlarge w3-wide w3-animate-opacity"></span>
   </div>
 </header>
 

--- a/main.js
+++ b/main.js
@@ -121,4 +121,48 @@ document.addEventListener('DOMContentLoaded', function() {
         observer.observe(element);
     });
 
+    // Dark mode toggle
+    const darkToggle = document.getElementById('darkModeToggle');
+    if(darkToggle){
+        darkToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            const icon = darkToggle.querySelector('i');
+            if(document.body.classList.contains('dark-mode')){
+                icon.classList.remove('fa-moon');
+                icon.classList.add('fa-sun');
+            }else{
+                icon.classList.remove('fa-sun');
+                icon.classList.add('fa-moon');
+            }
+        });
+    }
+
+    // Typed hero text
+    const typedEl = document.getElementById('typed-text');
+    if(typedEl){
+        const messages = ['Server Among Us', 'Welcome to the Future', 'Learn & Grow'];
+        let mIndex = 0;
+        let charIndex = 0;
+        function type(){
+            if(charIndex < messages[mIndex].length){
+                typedEl.textContent += messages[mIndex].charAt(charIndex);
+                charIndex++;
+                setTimeout(type, 100);
+            }else{
+                setTimeout(erase, 2000);
+            }
+        }
+        function erase(){
+            if(charIndex > 0){
+                typedEl.textContent = messages[mIndex].substring(0, charIndex-1);
+                charIndex--;
+                setTimeout(erase, 50);
+            }else{
+                mIndex = (mIndex + 1) % messages.length;
+                setTimeout(type, 500);
+            }
+        }
+        type();
+    }
+
 });


### PR DESCRIPTION
## Summary
- add dark mode styles and hero typing animation
- include dark mode toggle buttons in navbar
- initialize dark mode and typing effect in main.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411762047883309c0e4e3b474820b8